### PR TITLE
Fixed AAD Instance Base URL and AAD App.

### DIFF
--- a/upload_termination_records_GCC.ps1
+++ b/upload_termination_records_GCC.ps1
@@ -12,8 +12,8 @@ param
     [string] $csvFilePath
 )
 # Access Token Config
-$oAuthTokenEndpoint = "https://login.microsoftonline.us/$tenantId/oauth2/token"
-$resource = 'https://microsoft.onmicrosoft.com/4e476d41-2395-42be-89ff-34cb9186a1ac'
+$oAuthTokenEndpoint = "https://login.microsoftonline.com/$tenantId/oauth2/token"
+$resource = 'https://prdtrs01.prod.outlook.com/64342688-40f0-476d-8f18-ccf14147bae1'
 
 # Csv upload config
 $eventApiURl = "https://webhook-gcc.ingestion.office365.us/"


### PR DESCRIPTION
- The AAD Instance Base URL for GCC was incorrect. It should be ".com" instead of ".us". Bug: https://o365exchange.visualstudio.com/IP%20Engineering/_workitems/edit/1990877.
- Updated the AAD App Resource Id URI from New AAD App for GCC.

Tested with creating and pushing data for a new job in GCC.